### PR TITLE
bugfix/deploy-volumes-uri-port-missing-from-read

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![CircleCI](https://circleci.com/gh/packetloop/terraform-provider-singularity.svg?style=svg)](https://circleci.com/gh/packetloop/terraform-provider-singularity)
+[![GitHub release](https://img.shields.io/github/release/packetloop/terraform-provider-singularity.svg)](https://github.com/packetloop/terraform-provider-singularity/releases/)
 [![All Contributors](https://img.shields.io/github/contributors/packetloop/terraform-provider-singularity.svg?longCache=true&style=flat-square&colorB=orange&label=all%20contributors)](#contributors)
 [![Github All Releases](https://img.shields.io/github/downloads/packetloop/terraform-provider-singularity/total.svg)]()
 

--- a/mesos_singularity/resource_docker_deploy.go
+++ b/mesos_singularity/resource_docker_deploy.go
@@ -380,6 +380,39 @@ func resourceDockerDeployRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("num_ports", r.Body.PendingDeploy.NumPorts)
 		d.Set("command", r.Body.PendingDeploy.Command)
 		d.Set("envs", r.Body.PendingDeploy.TaskEnv)
+		if r.Body.PendingDeploy.Uris != nil {
+			mapURI := make([]map[string]interface{}, 0)
+			for _, a := range r.Body.PendingDeploy.Uris {
+				m := make(map[string]interface{})
+				m["cache"] = a.Cache
+				m["path"] = a.URI
+				m["extract"] = a.Extract
+				m["executable"] = a.Executable
+				mapURI = append(mapURI, m)
+			}
+		}
+		if r.Body.PendingDeploy.ContainerInfo.PortMappings != nil {
+			mapPort := make([]map[string]interface{}, 0)
+			for _, a := range r.Body.PendingDeploy.ContainerInfo.PortMappings {
+				m := make(map[string]interface{})
+				m["container_port"] = a.ContainerPort
+				m["container_port_type"] = a.ContainerPortType
+				m["host_port"] = a.HostPort
+				m["host_port_type"] = a.HostPortType
+				m["protocol"] = a.Protocol
+				mapPort = append(mapPort, m)
+			}
+		}
+		if r.Body.PendingDeploy.ContainerInfo.Volumes != nil {
+			mapVolumes := make([]map[string]interface{}, 0)
+			for _, a := range r.Body.PendingDeploy.ContainerInfo.Volumes {
+				m := make(map[string]interface{})
+				m["host_path"] = a.HostPath
+				m["container_path"] = a.ContainerPath
+				m["mode"] = a.Mode
+				mapVolumes = append(mapVolumes, m)
+			}
+		}
 		d.Set("port_mapping", r.Body.PendingDeploy.ContainerInfo.DockerInfo.PortMappings)
 		d.Set("volume", r.Body.PendingDeploy.ContainerInfo.Volumes)
 		d.Set("uri", r.Body.PendingDeploy.Uris)
@@ -395,9 +428,44 @@ func resourceDockerDeployRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("num_ports", r.Body.ActiveDeploy.NumPorts)
 		d.Set("command", r.Body.ActiveDeploy.Command)
 		d.Set("envs", r.Body.ActiveDeploy.Env)
-		d.Set("port_mapping", r.Body.ActiveDeploy.ContainerInfo.DockerInfo.PortMappings)
-		d.Set("volume", r.Body.ActiveDeploy.ContainerInfo.Volumes)
-		d.Set("uri", r.Body.ActiveDeploy.Uris)
+
+		if r.Body.ActiveDeploy.Uris != nil {
+			mapURI := make([]map[string]interface{}, 0)
+			for _, a := range r.Body.ActiveDeploy.Uris {
+				m := make(map[string]interface{})
+				m["cache"] = a.Cache
+				m["path"] = a.URI
+				m["extract"] = a.Extract
+				m["executable"] = a.Executable
+				mapURI = append(mapURI, m)
+			}
+			d.Set("uri", mapURI)
+		}
+		if r.Body.ActiveDeploy.ContainerInfo.PortMappings != nil {
+			mapPort := make([]map[string]interface{}, 0)
+			for _, a := range r.Body.ActiveDeploy.ContainerInfo.PortMappings {
+				m := make(map[string]interface{})
+				m["container_port"] = a.ContainerPort
+				m["container_port_type"] = a.ContainerPortType
+				m["host_port"] = a.HostPort
+				m["host_port_type"] = a.HostPortType
+				m["protocol"] = a.Protocol
+				mapPort = append(mapPort, m)
+			}
+			d.Set("port_mapping", mapPort)
+		}
+		if r.Body.ActiveDeploy.ContainerInfo.Volumes != nil {
+			mapVolumes := make([]map[string]interface{}, 0)
+			for _, a := range r.Body.ActiveDeploy.ContainerInfo.Volumes {
+				m := make(map[string]interface{})
+				m["host_path"] = a.HostPath
+				m["container_path"] = a.ContainerPath
+				m["mode"] = a.Mode
+				mapVolumes = append(mapVolumes, m)
+			}
+			d.Set("volume", mapVolumes)
+		}
+
 		d.Set("force_pull_image", r.Body.ActiveDeploy.ContainerInfo.DockerInfo.ForcePullImage)
 		d.Set("metadata", r.Body.ActiveDeploy.Metadata)
 	}

--- a/mesos_singularity/resource_request.go
+++ b/mesos_singularity/resource_request.go
@@ -36,7 +36,6 @@ func resourceRequest() *schema.Resource {
 			"num_retries_on_failure": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  3,
 				ForceNew: true,
 			},
 			"schedule": &schema.Schema{
@@ -196,8 +195,8 @@ func resourceRequestRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("request_type", r.Body.SingularityRequest.RequestType)
 	d.Set("slave_placement", r.Body.SingularityRequest.SlavePlacement)
 
-	// These two types of request does not expect instance number set.
-	if checkRequestTypeMatch(r.Body, "ON_DEMAND", "RUN_ONCE") {
+	// Only these three types of request expects instance number set.
+	if checkRequestTypeMatch(r.Body, "ON_DEMAND", "WORKER", "SERVICE") {
 		d.Set("instances", r.Body.SingularityRequest.Instances)
 	}
 	// Only a scheuled type service expect below parameters.


### PR DESCRIPTION
Fix when importing/setting typeset parameters. We expand this when
creating this parameter/s. Hence, when we read this, we need to flatten
this somehow.